### PR TITLE
[Feature/mission9]  리뷰 및 미션 관련 목록 조회 및 완료 처리 API 구현

### DIFF
--- a/spring/src/main/java/umc/spring/apiPayload/code/status/ErrorStatus.java
+++ b/spring/src/main/java/umc/spring/apiPayload/code/status/ErrorStatus.java
@@ -27,6 +27,7 @@ public enum ErrorStatus implements BaseErrorCode {
     REGION_NOT_FOUND(HttpStatus.NOT_FOUND,"REGION_4001", "존재하지 않는 지역입니다."),
 
     MISSION_NOT_FOUND(HttpStatus.NOT_FOUND,"MISSION_4001", "존재하지 않는 미션입니다."),
+    ALREADY_CHALLENGED(HttpStatus.BAD_REQUEST,"MISSION_4002", "이미 완료된 미션입니다."),
     ALREADY_CHALLENGING(HttpStatus.BAD_REQUEST,"MISSION_4002", "이미 도전 중인 미션입니다."),
 
     // 예시,,,

--- a/spring/src/main/java/umc/spring/converter/MemberConverter.java
+++ b/spring/src/main/java/umc/spring/converter/MemberConverter.java
@@ -2,10 +2,16 @@ package umc.spring.converter;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.data.domain.Page;
 import umc.spring.domain.Member;
+import umc.spring.domain.Review;
 import umc.spring.domain.enums.Gender;
 import umc.spring.web.dto.MemberRequestDTO;
 import umc.spring.web.dto.MemberResponseDTO;
+import umc.spring.web.dto.MemberResponseDTO.ReviewPreviewDTO;
+import umc.spring.web.dto.MemberResponseDTO.ReviewPreviewListDTO;
 
 public class MemberConverter {
 
@@ -39,6 +45,30 @@ public class MemberConverter {
                 .name(request.getName())
                 .memberPreferList(new ArrayList<>())
                 .email(request.getEmail())
+                .build();
+    }
+
+    public static ReviewPreviewDTO toReviewPreviewDTO(Review review) {
+        return ReviewPreviewDTO.builder()
+                .storeName(review.getStore().getName())
+                .body(review.getTitle())
+                .score(review.getScore())
+                .createdAt(review.getCreatedAt().toLocalDate())
+                .build();
+    }
+
+    public static ReviewPreviewListDTO toReviewPreviewListDTO(Page<Review> reviews) {
+        List<ReviewPreviewDTO> list = reviews.stream()
+                .map(MemberConverter::toReviewPreviewDTO)
+                .collect(Collectors.toList());
+
+        return ReviewPreviewListDTO.builder()
+                .reviewList(list)
+                .listSize(list.size())
+                .totalPage(reviews.getTotalPages())
+                .totalElements(reviews.getTotalElements())
+                .isFirst(reviews.isFirst())
+                .isLast(reviews.isLast())
                 .build();
     }
 }

--- a/spring/src/main/java/umc/spring/converter/MemberConverter.java
+++ b/spring/src/main/java/umc/spring/converter/MemberConverter.java
@@ -8,8 +8,11 @@ import org.springframework.data.domain.Page;
 import umc.spring.domain.Member;
 import umc.spring.domain.Review;
 import umc.spring.domain.enums.Gender;
+import umc.spring.domain.mapping.MemberMission;
 import umc.spring.web.dto.MemberRequestDTO;
 import umc.spring.web.dto.MemberResponseDTO;
+import umc.spring.web.dto.MemberResponseDTO.ChallengingMissionDTO;
+import umc.spring.web.dto.MemberResponseDTO.ChallengingMissionListDTO;
 import umc.spring.web.dto.MemberResponseDTO.ReviewPreviewDTO;
 import umc.spring.web.dto.MemberResponseDTO.ReviewPreviewListDTO;
 
@@ -71,4 +74,28 @@ public class MemberConverter {
                 .isLast(reviews.isLast())
                 .build();
     }
+    public static ChallengingMissionDTO toChallengingMissionDTO(MemberMission mm) {
+        return ChallengingMissionDTO.builder()
+                .missionSpec(mm.getMission().getMissionSpec())
+                .reward(mm.getMission().getReward())
+                .deadline(mm.getMission().getDeadline())
+                .storeName(mm.getMission().getStore().getName())
+                .build();
+    }
+
+    public static ChallengingMissionListDTO toChallengingMissionListDTO(Page<MemberMission> missionPage) {
+        List<ChallengingMissionDTO> missionList = missionPage.stream()
+                .map(MemberConverter::toChallengingMissionDTO)
+                .collect(Collectors.toList());
+
+        return ChallengingMissionListDTO.builder()
+                .missionList(missionList)
+                .listSize(missionList.size())
+                .totalPage(missionPage.getTotalPages())
+                .totalElements(missionPage.getTotalElements())
+                .isFirst(missionPage.isFirst())
+                .isLast(missionPage.isLast())
+                .build();
+    }
+
 }

--- a/spring/src/main/java/umc/spring/converter/ReviewConverter.java
+++ b/spring/src/main/java/umc/spring/converter/ReviewConverter.java
@@ -4,6 +4,7 @@ import umc.spring.domain.Member;
 import umc.spring.domain.Review;
 import umc.spring.domain.Store;
 import umc.spring.web.dto.ReviewRequestDTO;
+import umc.spring.web.dto.StoreResponseDTO;
 
 // ReviewConverter.java
 public class ReviewConverter {
@@ -16,5 +17,16 @@ public class ReviewConverter {
                 .store(store)
                 .build();
     }
+    public static StoreResponseDTO.CreateReviewResultDTO toCreateReviewResultDTO(Review review) {
+        return StoreResponseDTO.CreateReviewResultDTO.builder()
+                .reviewId(review.getId())
+                .title(review.getTitle())
+                .score(review.getScore())
+                .storeId(review.getStore().getId())
+                .memberId(review.getMember().getId())
+                .createdAt(review.getCreatedAt())
+                .build();
+    }
+
 }
 

--- a/spring/src/main/java/umc/spring/converter/StoreConverter.java
+++ b/spring/src/main/java/umc/spring/converter/StoreConverter.java
@@ -3,11 +3,14 @@ package umc.spring.converter;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
+import umc.spring.domain.Mission;
 import umc.spring.domain.Region;
 import umc.spring.domain.Review;
 import umc.spring.domain.Store;
 import umc.spring.web.dto.StoreRequestDTO.CreateStore;
 import umc.spring.web.dto.StoreResponseDTO;
+import umc.spring.web.dto.StoreResponseDTO.MissionPreviewDTO;
+import umc.spring.web.dto.StoreResponseDTO.MissionPreviewListDTO;
 
 public class StoreConverter {
     public static Store toStore(CreateStore request, Region region) {
@@ -36,6 +39,7 @@ public class StoreConverter {
                 .body(review.getTitle())
                 .build();
     }
+
     public static StoreResponseDTO.ReviewPreViewListDTO reviewPreViewListDTO(Page<Review> reviewList){
 
         List<StoreResponseDTO.ReviewPreViewDTO> reviewPreViewDTOList = reviewList.stream()
@@ -50,4 +54,28 @@ public class StoreConverter {
                 .reviewList(reviewPreViewDTOList)
                 .build();
     }
+    public static MissionPreviewDTO toMissionPreviewDTO(Mission mission) {
+        return StoreResponseDTO.MissionPreviewDTO.builder()
+                .missionSpec(mission.getMissionSpec())
+                .reward(mission.getReward())
+                .deadline(mission.getDeadline())
+                .build();
+    }
+
+    public static MissionPreviewListDTO toMissionPreviewListDTO(Page<Mission> missionPage) {
+        List<StoreResponseDTO.MissionPreviewDTO> missionList = missionPage.stream()
+                .map(StoreConverter::toMissionPreviewDTO)
+                .collect(Collectors.toList());
+
+        return StoreResponseDTO.MissionPreviewListDTO.builder()
+                .missionList(missionList)
+                .listSize(missionList.size())
+                .totalPage(missionPage.getTotalPages())
+                .totalElements(missionPage.getTotalElements())
+                .isFirst(missionPage.isFirst())
+                .isLast(missionPage.isLast())
+                .build();
+    }
+
+
 }

--- a/spring/src/main/java/umc/spring/converter/StoreConverter.java
+++ b/spring/src/main/java/umc/spring/converter/StoreConverter.java
@@ -1,8 +1,13 @@
 package umc.spring.converter;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.data.domain.Page;
 import umc.spring.domain.Region;
+import umc.spring.domain.Review;
 import umc.spring.domain.Store;
 import umc.spring.web.dto.StoreRequestDTO.CreateStore;
+import umc.spring.web.dto.StoreResponseDTO;
 
 public class StoreConverter {
     public static Store toStore(CreateStore request, Region region) {
@@ -11,6 +16,38 @@ public class StoreConverter {
                 .address(request.getAddress())
                 .region(region)
                 .score(null)
+                .build();
+    }
+    public static StoreResponseDTO.CreateStoreResultDTO toCreateStoreResultDTO(Store store) {
+        return StoreResponseDTO.CreateStoreResultDTO.builder()
+                .storeId(store.getId())
+                .name(store.getName())
+                .address(store.getAddress())
+                .score(store.getScore())
+                .regionId(store.getRegion().getId())
+                .createdAt(store.getCreatedAt())
+                .build();
+    }
+    public static StoreResponseDTO.ReviewPreViewDTO reviewPreViewDTO(Review review){
+        return StoreResponseDTO.ReviewPreViewDTO.builder()
+                .ownerNickname(review.getMember().getName())
+                .score(review.getScore())
+                .createdAt(review.getCreatedAt().toLocalDate())
+                .body(review.getTitle())
+                .build();
+    }
+    public static StoreResponseDTO.ReviewPreViewListDTO reviewPreViewListDTO(Page<Review> reviewList){
+
+        List<StoreResponseDTO.ReviewPreViewDTO> reviewPreViewDTOList = reviewList.stream()
+                .map(StoreConverter::reviewPreViewDTO).collect(Collectors.toList());
+
+        return StoreResponseDTO.ReviewPreViewListDTO.builder()
+                .isLast(reviewList.isLast())
+                .isFirst(reviewList.isFirst())
+                .totalPage(reviewList.getTotalPages())
+                .totalElements(reviewList.getTotalElements())
+                .listSize(reviewPreViewDTOList.size())
+                .reviewList(reviewPreViewDTOList)
                 .build();
     }
 }

--- a/spring/src/main/java/umc/spring/domain/mapping/MemberMission.java
+++ b/spring/src/main/java/umc/spring/domain/mapping/MemberMission.java
@@ -16,7 +16,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import umc.spring.domain.Member;
 import umc.spring.domain.Mission;
-import umc.spring.domain.Store;
 import umc.spring.domain.common.BaseEntity;
 import umc.spring.domain.enums.MissionStatus;
 
@@ -51,5 +50,9 @@ public class MemberMission extends BaseEntity {
                 ", mission=" + (mission != null ? mission.getMissionSpec() : "null") +
                 '}';
     }
+    public void changeStatus(MissionStatus newStatus) {
+        this.status = newStatus;
+    }
+
 
 }

--- a/spring/src/main/java/umc/spring/repository/MissionRepository/MemberMissionRepository.java
+++ b/spring/src/main/java/umc/spring/repository/MissionRepository/MemberMissionRepository.java
@@ -1,8 +1,16 @@
 package umc.spring.repository.MissionRepository;
 
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import umc.spring.domain.Member;
+import umc.spring.domain.enums.MissionStatus;
 import umc.spring.domain.mapping.MemberMission;
 
 public interface MemberMissionRepository extends JpaRepository<MemberMission, Long> {
     boolean existsByMember_IdAndMission_Id(Long memberId, Long missionId);
+    Page<MemberMission> findAllByMemberAndStatus(Member member, MissionStatus status, Pageable pageable);
+    Optional<MemberMission> findByIdAndMemberId(Long memberMissionId, Long memberId);
+
 }

--- a/spring/src/main/java/umc/spring/repository/MissionRepository/MissionRepository.java
+++ b/spring/src/main/java/umc/spring/repository/MissionRepository/MissionRepository.java
@@ -1,8 +1,12 @@
 package umc.spring.repository.MissionRepository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import umc.spring.domain.Mission;
+import umc.spring.domain.Store;
 
 public interface MissionRepository extends JpaRepository<Mission, Long>, MissionRepositoryCustom {
+    Page<Mission> findAllByStore(Store store, Pageable pageable);
 }
 

--- a/spring/src/main/java/umc/spring/repository/ReviewRepository/ReviewRepository.java
+++ b/spring/src/main/java/umc/spring/repository/ReviewRepository/ReviewRepository.java
@@ -1,8 +1,12 @@
 package umc.spring.repository.ReviewRepository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import umc.spring.domain.Review;
+import umc.spring.domain.Store;
 
 public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRepositoryCustom {
+    Page<Review> findAllByStore(Store store, PageRequest pageRequest);
 }
 

--- a/spring/src/main/java/umc/spring/repository/ReviewRepository/ReviewRepository.java
+++ b/spring/src/main/java/umc/spring/repository/ReviewRepository/ReviewRepository.java
@@ -2,11 +2,14 @@ package umc.spring.repository.ReviewRepository;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import umc.spring.domain.Member;
 import umc.spring.domain.Review;
 import umc.spring.domain.Store;
 
 public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRepositoryCustom {
     Page<Review> findAllByStore(Store store, PageRequest pageRequest);
+    Page<Review> findAllByMember(Member member, Pageable pageable);
 }
 

--- a/spring/src/main/java/umc/spring/service/MemberService/MemberCommandService.java
+++ b/spring/src/main/java/umc/spring/service/MemberService/MemberCommandService.java
@@ -7,4 +7,6 @@ import umc.spring.web.dto.MemberRequestDTO;
 public interface MemberCommandService {
     @Transactional
     Member joinMember(MemberRequestDTO.JoinDto request);
+    void completeMission(Long memberId, Long memberMissionId);
+
 }

--- a/spring/src/main/java/umc/spring/service/MemberService/MemberCommandServiceImpl.java
+++ b/spring/src/main/java/umc/spring/service/MemberService/MemberCommandServiceImpl.java
@@ -7,13 +7,17 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import umc.spring.apiPayload.code.status.ErrorStatus;
 import umc.spring.apiPayload.exception.handler.FoodCategoryHandler;
+import umc.spring.apiPayload.exception.handler.MemberHandler;
 import umc.spring.converter.MemberConverter;
 import umc.spring.converter.MemberPreferConverter;
 import umc.spring.domain.FoodCategory;
 import umc.spring.domain.Member;
+import umc.spring.domain.enums.MissionStatus;
+import umc.spring.domain.mapping.MemberMission;
 import umc.spring.domain.mapping.MemberPrefer;
 import umc.spring.repository.FoodCategoryRepository.FoodCategoryRepository;
 import umc.spring.repository.MemberRepository.MemberRepository;
+import umc.spring.repository.MissionRepository.MemberMissionRepository;
 import umc.spring.web.dto.MemberRequestDTO;
 
 @Service
@@ -23,6 +27,7 @@ public class MemberCommandServiceImpl implements MemberCommandService{
     private final MemberRepository memberRepository;
 
     private final FoodCategoryRepository foodCategoryRepository;
+    private final MemberMissionRepository memberMissionRepository;
 
     @Transactional
     @Override
@@ -43,4 +48,17 @@ public class MemberCommandServiceImpl implements MemberCommandService{
 
         return memberRepository.save(newMember);
     }
+    @Override
+    @Transactional
+    public void completeMission(Long memberId, Long memberMissionId) {
+        MemberMission memberMission = memberMissionRepository.findByIdAndMemberId(memberMissionId, memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MISSION_NOT_FOUND));
+
+        if (memberMission.getStatus() == MissionStatus.COMPLETE) {
+            throw new MemberHandler(ErrorStatus.ALREADY_CHALLENGING); // 에러 메시지를 바꿔도 좋습니다
+        }
+
+        memberMission.changeStatus(MissionStatus.COMPLETE);
+    }
+
 }

--- a/spring/src/main/java/umc/spring/service/MemberService/MemberQueryService.java
+++ b/spring/src/main/java/umc/spring/service/MemberService/MemberQueryService.java
@@ -1,13 +1,19 @@
 package umc.spring.service.MemberService;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import umc.spring.domain.Member;
-
-import java.util.Optional;
+import umc.spring.domain.Mission;
 import umc.spring.domain.Review;
+import umc.spring.domain.mapping.MemberMission;
 
 public interface MemberQueryService {
     Optional<Member> getMemberInfo(Long memberId);
-
     Page<Review> getMyReviews(Long memberId, int page);
+    List<Mission> getMissionsByRegionBeforeCursor(Long regionId, LocalDateTime cursorTime, int limit);
+
+    Page<MemberMission> getChallengingMissions(Long memberId, int page);
+
 }

--- a/spring/src/main/java/umc/spring/service/MemberService/MemberQueryService.java
+++ b/spring/src/main/java/umc/spring/service/MemberService/MemberQueryService.java
@@ -1,9 +1,13 @@
 package umc.spring.service.MemberService;
 
+import org.springframework.data.domain.Page;
 import umc.spring.domain.Member;
 
 import java.util.Optional;
+import umc.spring.domain.Review;
 
 public interface MemberQueryService {
     Optional<Member> getMemberInfo(Long memberId);
+
+    Page<Review> getMyReviews(Long memberId, int page);
 }

--- a/spring/src/main/java/umc/spring/service/MemberService/MemberQueryServiceImpl.java
+++ b/spring/src/main/java/umc/spring/service/MemberService/MemberQueryServiceImpl.java
@@ -1,5 +1,7 @@
 package umc.spring.service.MemberService;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -9,8 +11,12 @@ import org.springframework.transaction.annotation.Transactional;
 import umc.spring.apiPayload.code.status.ErrorStatus;
 import umc.spring.apiPayload.exception.handler.MemberHandler;
 import umc.spring.domain.Member;
+import umc.spring.domain.Mission;
 import umc.spring.domain.Review;
+import umc.spring.domain.enums.MissionStatus;
+import umc.spring.domain.mapping.MemberMission;
 import umc.spring.repository.MemberRepository.MemberRepository;
+import umc.spring.repository.MissionRepository.MemberMissionRepository;
 import umc.spring.repository.ReviewRepository.ReviewRepository;
 
 @Service
@@ -20,6 +26,7 @@ public class MemberQueryServiceImpl implements MemberQueryService {
 
     private final MemberRepository memberRepository;
     private final ReviewRepository reviewRepository;
+    private final MemberMissionRepository memberMissionRepository;
 
     @Override
     public Optional<Member> getMemberInfo(Long memberId) {
@@ -33,5 +40,21 @@ public class MemberQueryServiceImpl implements MemberQueryService {
 
         return reviewRepository.findAllByMember(member, PageRequest.of(page, 10));
     }
+
+    @Override
+    public List<Mission> getMissionsByRegionBeforeCursor(Long regionId, LocalDateTime cursorTime, int limit) {
+        return null;
+    }
+
+    @Override
+    public Page<MemberMission> getChallengingMissions(Long memberId, int page) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        return memberMissionRepository.findAllByMemberAndStatus(member, MissionStatus.CHALLENGING,
+                PageRequest.of(page, 10));
+    }
+
 }
+
 

--- a/spring/src/main/java/umc/spring/service/MemberService/MemberQueryServiceImpl.java
+++ b/spring/src/main/java/umc/spring/service/MemberService/MemberQueryServiceImpl.java
@@ -1,12 +1,17 @@
 package umc.spring.service.MemberService;
 
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.spring.apiPayload.code.status.ErrorStatus;
+import umc.spring.apiPayload.exception.handler.MemberHandler;
 import umc.spring.domain.Member;
+import umc.spring.domain.Review;
 import umc.spring.repository.MemberRepository.MemberRepository;
-
-import java.util.Optional;
+import umc.spring.repository.ReviewRepository.ReviewRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -14,10 +19,19 @@ import java.util.Optional;
 public class MemberQueryServiceImpl implements MemberQueryService {
 
     private final MemberRepository memberRepository;
+    private final ReviewRepository reviewRepository;
 
     @Override
     public Optional<Member> getMemberInfo(Long memberId) {
         return memberRepository.findMemberInfo(memberId);
+    }
+
+    @Override
+    public Page<Review> getMyReviews(Long memberId, int page) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        return reviewRepository.findAllByMember(member, PageRequest.of(page, 10));
     }
 }
 

--- a/spring/src/main/java/umc/spring/service/MissionService/MissionQueryService.java
+++ b/spring/src/main/java/umc/spring/service/MissionService/MissionQueryService.java
@@ -1,14 +1,15 @@
 package umc.spring.service.MissionService;
 
 import java.time.LocalDateTime;
-import umc.spring.domain.Mission;
-
 import java.util.List;
+import umc.spring.domain.Mission;
 import umc.spring.domain.enums.MissionStatus;
 
 public interface MissionQueryService {
     List<Mission> getMissionsByStatusAndMember(Long memberId, MissionStatus status, int offset, int limit);
+
     List<Mission> getMissionsByRegionBeforeCursor(Long regionId, LocalDateTime cursorTime, int limit);
+
 
 }
 

--- a/spring/src/main/java/umc/spring/service/MissionService/MissionQueryServiceImpl.java
+++ b/spring/src/main/java/umc/spring/service/MissionService/MissionQueryServiceImpl.java
@@ -1,14 +1,16 @@
 package umc.spring.service.MissionService;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.spring.apiPayload.code.status.ErrorStatus;
+import umc.spring.apiPayload.exception.handler.MemberHandler;
 import umc.spring.domain.Mission;
 import umc.spring.domain.enums.MissionStatus;
+import umc.spring.domain.mapping.MemberMission;
 import umc.spring.repository.MissionRepository.MissionRepository;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +28,7 @@ public class MissionQueryServiceImpl implements MissionQueryService {
     public List<Mission> getMissionsByRegionBeforeCursor(Long regionId, LocalDateTime cursorTime, int limit) {
         return missionRepository.findMissionsByRegionBeforeCursor(regionId, cursorTime, limit);
     }
+
 
 }
 

--- a/spring/src/main/java/umc/spring/service/StoreService/StoreCommandService.java
+++ b/spring/src/main/java/umc/spring/service/StoreService/StoreCommandService.java
@@ -1,8 +1,9 @@
 package umc.spring.service.StoreService;
 
+import umc.spring.domain.Store;
 import umc.spring.web.dto.StoreRequestDTO.CreateStore;
 
 public interface StoreCommandService {
-    void createStore(Long regionId, CreateStore request);
+    Store createStore(Long regionId, CreateStore request);
 }
 

--- a/spring/src/main/java/umc/spring/service/StoreService/StoreCommandServiceImpl.java
+++ b/spring/src/main/java/umc/spring/service/StoreService/StoreCommandServiceImpl.java
@@ -21,11 +21,12 @@ public class StoreCommandServiceImpl implements StoreCommandService {
 
     @Override
     @Transactional
-    public void createStore(Long regionId, CreateStore dto) {
+    public Store createStore(Long regionId, CreateStore dto) {
         Region region = regionRepository.findById(regionId)
                 .orElseThrow(() -> new RegionHandler(ErrorStatus.REGION_NOT_FOUND));
 
         Store store = StoreConverter.toStore(dto, region);
         storeRepository.save(store);
+        return store;
     }
 }

--- a/spring/src/main/java/umc/spring/service/StoreService/StoreQueryService.java
+++ b/spring/src/main/java/umc/spring/service/StoreService/StoreQueryService.java
@@ -1,12 +1,15 @@
 package umc.spring.service.StoreService;
 
-import umc.spring.domain.Store;
-
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import umc.spring.domain.Review;
+import umc.spring.domain.Store;
 
 public interface StoreQueryService {
 
     Optional<Store> findStore(Long id);
     List<Store> findStoresByNameAndScore(String name, Float score);
+
+    Page<Review> getReviewList(Long storeId, Integer page);
 }

--- a/spring/src/main/java/umc/spring/service/StoreService/StoreQueryService.java
+++ b/spring/src/main/java/umc/spring/service/StoreService/StoreQueryService.java
@@ -3,6 +3,7 @@ package umc.spring.service.StoreService;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
+import umc.spring.domain.Mission;
 import umc.spring.domain.Review;
 import umc.spring.domain.Store;
 
@@ -12,4 +13,5 @@ public interface StoreQueryService {
     List<Store> findStoresByNameAndScore(String name, Float score);
 
     Page<Review> getReviewList(Long storeId, Integer page);
+    Page<Mission> getMissionList(Long storeId, int page);
 }

--- a/spring/src/main/java/umc/spring/service/StoreService/StoreQueryServiceImpl.java
+++ b/spring/src/main/java/umc/spring/service/StoreService/StoreQueryServiceImpl.java
@@ -7,8 +7,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.spring.apiPayload.code.status.ErrorStatus;
+import umc.spring.apiPayload.exception.handler.StoreHandler;
+import umc.spring.domain.Mission;
 import umc.spring.domain.Review;
 import umc.spring.domain.Store;
+import umc.spring.repository.MissionRepository.MissionRepository;
 import umc.spring.repository.ReviewRepository.ReviewRepository;
 import umc.spring.repository.StoreRepository.StoreRepository;
 
@@ -19,6 +23,7 @@ public class StoreQueryServiceImpl implements StoreQueryService{
 
     private final StoreRepository storeRepository;
     private final ReviewRepository reviewRepository;
+    private final MissionRepository missionRepository;
 
     @Override
     public Optional<Store> findStore(Long id) {
@@ -39,5 +44,13 @@ public class StoreQueryServiceImpl implements StoreQueryService{
         Store store = storeRepository.findById(StoreId).get();
 
         return reviewRepository.findAllByStore(store, PageRequest.of(page, 10));
+    }
+
+    @Override
+    public Page<Mission> getMissionList(Long storeId, int page) {
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new StoreHandler(ErrorStatus.STORE_NOT_FOUND));
+
+        return missionRepository.findAllByStore(store, PageRequest.of(page, 10));
     }
 }

--- a/spring/src/main/java/umc/spring/service/StoreService/StoreQueryServiceImpl.java
+++ b/spring/src/main/java/umc/spring/service/StoreService/StoreQueryServiceImpl.java
@@ -1,13 +1,16 @@
 package umc.spring.service.StoreService;
 
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import umc.spring.domain.Store;
-import umc.spring.repository.StoreRepository.StoreRepository;
-
 import java.util.List;
 import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.spring.domain.Review;
+import umc.spring.domain.Store;
+import umc.spring.repository.ReviewRepository.ReviewRepository;
+import umc.spring.repository.StoreRepository.StoreRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +18,7 @@ import java.util.Optional;
 public class StoreQueryServiceImpl implements StoreQueryService{
 
     private final StoreRepository storeRepository;
+    private final ReviewRepository reviewRepository;
 
     @Override
     public Optional<Store> findStore(Long id) {
@@ -28,5 +32,12 @@ public class StoreQueryServiceImpl implements StoreQueryService{
         filteredStores.forEach(store -> System.out.println("Store: " + store));
 
         return filteredStores;
+    }
+
+    @Override
+    public Page<Review> getReviewList(Long StoreId, Integer page) {
+        Store store = storeRepository.findById(StoreId).get();
+
+        return reviewRepository.findAllByStore(store, PageRequest.of(page, 10));
     }
 }

--- a/spring/src/main/java/umc/spring/validation/annotation/PositiveOrZeroPage.java
+++ b/spring/src/main/java/umc/spring/validation/annotation/PositiveOrZeroPage.java
@@ -2,19 +2,19 @@ package umc.spring.validation.annotation;
 
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import umc.spring.validation.validator.StoreExistValidator;
+import umc.spring.validation.validator.PageValidator;
 
-// ExistStore.java
-@Target({ ElementType.FIELD, ElementType.PARAMETER })
+@Documented
+@Constraint(validatedBy = PageValidator.class)
+@Target({ElementType.PARAMETER, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
-@Constraint(validatedBy = StoreExistValidator.class)
-public @interface ExistStore {
-    String message() default "존재하지 않는 가게입니다.";
+public @interface PositiveOrZeroPage {
+    String message() default "페이지 번호는 0 이상의 정수여야 합니다.";
     Class<?>[] groups() default {};
     Class<? extends Payload>[] payload() default {};
 }
-

--- a/spring/src/main/java/umc/spring/validation/annotation/ValidPage.java
+++ b/spring/src/main/java/umc/spring/validation/annotation/ValidPage.java
@@ -2,19 +2,18 @@ package umc.spring.validation.annotation;
 
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
-import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import umc.spring.validation.validator.PageValidator;
 
-@Documented
-@Constraint(validatedBy = PageValidator.class)
-@Target({ElementType.PARAMETER, ElementType.FIELD})
+@Target({ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
-public @interface PositiveOrZeroPage {
-    String message() default "페이지 번호는 0 이상의 정수여야 합니다.";
+@Constraint(validatedBy = PageValidator.class)
+public @interface ValidPage {
+    String message() default "페이지는 1 이상의 정수여야 합니다.";
     Class<?>[] groups() default {};
     Class<? extends Payload>[] payload() default {};
 }
+

--- a/spring/src/main/java/umc/spring/validation/validator/PageValidator.java
+++ b/spring/src/main/java/umc/spring/validation/validator/PageValidator.java
@@ -1,0 +1,13 @@
+package umc.spring.validation.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import umc.spring.validation.annotation.PositiveOrZeroPage;
+
+public class PageValidator implements ConstraintValidator<PositiveOrZeroPage, Integer> {
+
+    @Override
+    public boolean isValid(Integer value, ConstraintValidatorContext context) {
+        return value != null && value >= 0;
+    }
+}

--- a/spring/src/main/java/umc/spring/validation/validator/PageValidator.java
+++ b/spring/src/main/java/umc/spring/validation/validator/PageValidator.java
@@ -2,12 +2,12 @@ package umc.spring.validation.validator;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
-import umc.spring.validation.annotation.PositiveOrZeroPage;
+import umc.spring.validation.annotation.ValidPage;
 
-public class PageValidator implements ConstraintValidator<PositiveOrZeroPage, Integer> {
+public class PageValidator implements ConstraintValidator<ValidPage, Integer> {
 
     @Override
     public boolean isValid(Integer value, ConstraintValidatorContext context) {
-        return value != null && value >= 0;
+        return value != null && value >= 1;
     }
 }

--- a/spring/src/main/java/umc/spring/web/controller/MemberRestController.java
+++ b/spring/src/main/java/umc/spring/web/controller/MemberRestController.java
@@ -1,18 +1,27 @@
 package umc.spring.web.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import umc.spring.apiPayload.ApiResponse;
 import umc.spring.converter.MemberConverter;
 import umc.spring.domain.Member;
+import umc.spring.domain.Review;
 import umc.spring.service.MemberService.MemberCommandService;
+import umc.spring.service.MemberService.MemberQueryService;
+import umc.spring.validation.annotation.ValidPage;
 import umc.spring.web.dto.MemberRequestDTO;
 import umc.spring.web.dto.MemberResponseDTO;
-import umc.spring.web.dto.MemberResponseDTO.JoinResultDTO;
+import umc.spring.web.dto.MemberResponseDTO.ReviewPreviewListDTO;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,10 +29,25 @@ import umc.spring.web.dto.MemberResponseDTO.JoinResultDTO;
 public class MemberRestController {
 
     private final MemberCommandService memberCommandService;
+    private final MemberQueryService memberQueryService;
 
     @PostMapping("/")
     public ApiResponse<MemberResponseDTO.JoinResultDTO> join(@RequestBody @Valid MemberRequestDTO.JoinDto request){
         Member member = memberCommandService.joinMember(request);
         return ApiResponse.onSuccess(MemberConverter.toJoinResultDTO(member));
     }
+
+    @GetMapping("/members/{memberId}/reviews")
+    @Operation(summary = "내가 작성한 리뷰 목록 조회 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공")
+    })
+    public ApiResponse<ReviewPreviewListDTO> getMyReviews(
+            @PathVariable Long memberId,
+            @ValidPage @RequestParam("page") Integer page) {
+
+        Page<Review> reviews = memberQueryService.getMyReviews(memberId, page - 1);
+        return ApiResponse.onSuccess(MemberConverter.toReviewPreviewListDTO(reviews));
+    }
+
 }

--- a/spring/src/main/java/umc/spring/web/controller/MemberRestController.java
+++ b/spring/src/main/java/umc/spring/web/controller/MemberRestController.java
@@ -40,7 +40,7 @@ public class MemberRestController {
         return ApiResponse.onSuccess(MemberConverter.toJoinResultDTO(member));
     }
 
-    @GetMapping("/members/{memberId}/reviews")
+    @GetMapping("/{memberId}/reviews")
     @Operation(summary = "내가 작성한 리뷰 목록 조회 API")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공")

--- a/spring/src/main/java/umc/spring/web/controller/MemberRestController.java
+++ b/spring/src/main/java/umc/spring/web/controller/MemberRestController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -25,6 +26,7 @@ import umc.spring.web.dto.MemberResponseDTO.ReviewPreviewListDTO;
 
 @RestController
 @RequiredArgsConstructor
+@Validated
 @RequestMapping("/members")
 public class MemberRestController {
 

--- a/spring/src/main/java/umc/spring/web/controller/MemberRestController.java
+++ b/spring/src/main/java/umc/spring/web/controller/MemberRestController.java
@@ -17,6 +17,7 @@ import umc.spring.apiPayload.ApiResponse;
 import umc.spring.converter.MemberConverter;
 import umc.spring.domain.Member;
 import umc.spring.domain.Review;
+import umc.spring.domain.mapping.MemberMission;
 import umc.spring.service.MemberService.MemberCommandService;
 import umc.spring.service.MemberService.MemberQueryService;
 import umc.spring.validation.annotation.ValidPage;
@@ -51,5 +52,18 @@ public class MemberRestController {
         Page<Review> reviews = memberQueryService.getMyReviews(memberId, page - 1);
         return ApiResponse.onSuccess(MemberConverter.toReviewPreviewListDTO(reviews));
     }
+    @GetMapping("/{memberId}/missions")
+    @Operation(summary = "내가 진행 중인 미션 목록 조회 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공")
+    })
+    public ApiResponse<MemberResponseDTO.ChallengingMissionListDTO> getMyChallengingMissions(
+            @PathVariable Long memberId,
+            @ValidPage @RequestParam("page") Integer page) {
+
+        Page<MemberMission> missions = memberQueryService.getChallengingMissions(memberId, page - 1);
+        return ApiResponse.onSuccess(MemberConverter.toChallengingMissionListDTO(missions));
+    }
+
 
 }

--- a/spring/src/main/java/umc/spring/web/controller/MissionRestController.java
+++ b/spring/src/main/java/umc/spring/web/controller/MissionRestController.java
@@ -1,14 +1,18 @@
 package umc.spring.web.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import umc.spring.apiPayload.ApiResponse;
+import umc.spring.service.MemberService.MemberCommandService;
 import umc.spring.service.MissionService.MissionCommandService;
 import umc.spring.validation.annotation.NotAlreadyChallenging;
 import umc.spring.web.dto.MissionRequestDTO;
@@ -21,6 +25,7 @@ public class MissionRestController {
 
     private final MissionCommandService missionCommandService;
     private final MissionCommandService missionChallengeService;
+    private final MemberCommandService memberCommandService;
 
 
     @PostMapping("/{storeId}/missions")
@@ -35,5 +40,20 @@ public class MissionRestController {
         missionChallengeService.challengeMission(missionId);
         return ApiResponse.onSuccess("미션 도전 완료");
     }
+    @PatchMapping("/{memberId}/missions/{memberMissionId}/complete")
+    @Operation(summary = "도전 중인 미션을 완료 처리하는 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MISSION_4001", description = "존재하지 않는 미션입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MISSION_4002", description = "이미 완료된 미션입니다.")
+    })
+    public ApiResponse<String> completeMission(
+            @PathVariable Long memberId,
+            @PathVariable Long memberMissionId) {
+
+        memberCommandService.completeMission(memberId, memberMissionId);
+        return ApiResponse.onSuccess("미션 완료 처리 성공");
+    }
+
 }
 

--- a/spring/src/main/java/umc/spring/web/controller/ReviewRestController.java
+++ b/spring/src/main/java/umc/spring/web/controller/ReviewRestController.java
@@ -2,10 +2,17 @@ package umc.spring.web.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import umc.spring.apiPayload.ApiResponse;
+import umc.spring.converter.ReviewConverter;
+import umc.spring.domain.Review;
 import umc.spring.service.ReviewService.ReviewCommandService;
 import umc.spring.web.dto.ReviewRequestDTO.CreateReview;
+import umc.spring.web.dto.StoreResponseDTO;
 
 @RestController
 @RequiredArgsConstructor
@@ -15,10 +22,10 @@ public class ReviewRestController {
     private final ReviewCommandService reviewCommandService;
 
     @PostMapping("/{storeId}/reviews")
-    public ApiResponse<String> createReview(@PathVariable Long storeId,
-                                            @RequestBody @Valid CreateReview request) {
-        reviewCommandService.createReview(storeId, request);
-        return ApiResponse.onSuccess("리뷰 등록 완료");
+    public ApiResponse<StoreResponseDTO.CreateReviewResultDTO> createReview(@PathVariable Long storeId,
+                                                                            @RequestBody @Valid CreateReview request) {
+        Review review =reviewCommandService.createReview(storeId, request);
+        return ApiResponse.onSuccess(ReviewConverter.toCreateReviewResultDTO(review));
     }
 }
 

--- a/spring/src/main/java/umc/spring/web/controller/StoreRestController.java
+++ b/spring/src/main/java/umc/spring/web/controller/StoreRestController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import umc.spring.apiPayload.ApiResponse;
 import umc.spring.converter.StoreConverter;
+import umc.spring.domain.Mission;
 import umc.spring.domain.Review;
 import umc.spring.domain.Store;
 import umc.spring.service.StoreService.StoreCommandService;
@@ -61,5 +62,18 @@ public class StoreRestController {
         return ApiResponse.onSuccess(StoreConverter.reviewPreViewListDTO(reviewPage));
 
     }
+    @GetMapping("/{storeId}/missions")
+    @Operation(summary = "특정 가게의 미션 목록 조회 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공")
+    })
+    public ApiResponse<StoreResponseDTO.MissionPreviewListDTO> getMissionList(
+            @ExistStore @PathVariable Long storeId,
+            @ValidPage @RequestParam(name = "page") Integer page) {
+
+        Page<Mission> missionPage = storeQueryService.getMissionList(storeId, page - 1);
+        return ApiResponse.onSuccess(StoreConverter.toMissionPreviewListDTO(missionPage));
+    }
+
 }
 

--- a/spring/src/main/java/umc/spring/web/controller/StoreRestController.java
+++ b/spring/src/main/java/umc/spring/web/controller/StoreRestController.java
@@ -1,24 +1,64 @@
 package umc.spring.web.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.data.domain.Page;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import umc.spring.apiPayload.ApiResponse;
+import umc.spring.converter.StoreConverter;
+import umc.spring.domain.Review;
+import umc.spring.domain.Store;
 import umc.spring.service.StoreService.StoreCommandService;
+import umc.spring.service.StoreService.StoreQueryService;
+import umc.spring.validation.annotation.ExistStore;
+import umc.spring.validation.annotation.PositiveOrZeroPage;
 import umc.spring.web.dto.StoreRequestDTO.CreateStore;
+import umc.spring.web.dto.StoreResponseDTO;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/regions")
+@Validated
+@RequestMapping("/stores")
 public class StoreRestController {
 
     private final StoreCommandService storeCommandService;
+    private final StoreQueryService storeQueryService;
 
     @PostMapping("/{regionId}/stores")
-    public ApiResponse<String> createStore(@PathVariable Long regionId,
-                                           @RequestBody @Valid CreateStore request) {
-        storeCommandService.createStore(regionId, request);
-        return ApiResponse.onSuccess("가게 등록 완료");
+    public ApiResponse<StoreResponseDTO.CreateStoreResultDTO> createStore(@PathVariable Long regionId,
+                                                                          @RequestBody @Valid CreateStore request) {
+        Store store =storeCommandService.createStore(regionId, request);
+        return ApiResponse.onSuccess(StoreConverter.toCreateStoreResultDTO(store));
+    }
+
+    @GetMapping("/{storeId}/reviews")
+    @Operation(summary = "특정 가게의 리뷰 목록 조회 API",description = "특정 가게의 리뷰들의 목록을 조회하는 API이며, 페이징을 포함합니다. query String 으로 page 번호를 주세요")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "acess 토큰 만료",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "acess 토큰 모양이 이상함",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    @Parameters({
+            @Parameter(name = "storeId", description = "가게의 아이디, path variable 입니다!")
+    })
+    public ApiResponse<StoreResponseDTO.ReviewPreViewListDTO> getReviewList(@ExistStore @PathVariable(name = "storeId") Long storeId,@PositiveOrZeroPage @RequestParam(name = "page") Integer page){
+        Page<Review> reviewPage = storeQueryService.getReviewList(storeId, page);
+        return ApiResponse.onSuccess(StoreConverter.reviewPreViewListDTO(reviewPage));
+
     }
 }
 

--- a/spring/src/main/java/umc/spring/web/controller/StoreRestController.java
+++ b/spring/src/main/java/umc/spring/web/controller/StoreRestController.java
@@ -24,7 +24,7 @@ import umc.spring.domain.Store;
 import umc.spring.service.StoreService.StoreCommandService;
 import umc.spring.service.StoreService.StoreQueryService;
 import umc.spring.validation.annotation.ExistStore;
-import umc.spring.validation.annotation.PositiveOrZeroPage;
+import umc.spring.validation.annotation.ValidPage;
 import umc.spring.web.dto.StoreRequestDTO.CreateStore;
 import umc.spring.web.dto.StoreResponseDTO;
 
@@ -55,8 +55,9 @@ public class StoreRestController {
     @Parameters({
             @Parameter(name = "storeId", description = "가게의 아이디, path variable 입니다!")
     })
-    public ApiResponse<StoreResponseDTO.ReviewPreViewListDTO> getReviewList(@ExistStore @PathVariable(name = "storeId") Long storeId,@PositiveOrZeroPage @RequestParam(name = "page") Integer page){
-        Page<Review> reviewPage = storeQueryService.getReviewList(storeId, page);
+    public ApiResponse<StoreResponseDTO.ReviewPreViewListDTO> getReviewList(@ExistStore @PathVariable(name = "storeId") Long storeId,
+                                                                            @ValidPage @RequestParam(name = "page") Integer page){
+        Page<Review> reviewPage = storeQueryService.getReviewList(storeId, page - 1);  // 여기!
         return ApiResponse.onSuccess(StoreConverter.reviewPreViewListDTO(reviewPage));
 
     }

--- a/spring/src/main/java/umc/spring/web/dto/MemberResponseDTO.java
+++ b/spring/src/main/java/umc/spring/web/dto/MemberResponseDTO.java
@@ -41,5 +41,29 @@ public class MemberResponseDTO {
         private Boolean isFirst;
         private Boolean isLast;
     }
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ChallengingMissionDTO {
+        private String missionSpec;
+        private Integer reward;
+        private LocalDate deadline;
+        private String storeName;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ChallengingMissionListDTO {
+        private List<ChallengingMissionDTO> missionList;
+        private Integer listSize;
+        private Integer totalPage;
+        private Long totalElements;
+        private Boolean isFirst;
+        private Boolean isLast;
+    }
+
 
 }

--- a/spring/src/main/java/umc/spring/web/dto/MemberResponseDTO.java
+++ b/spring/src/main/java/umc/spring/web/dto/MemberResponseDTO.java
@@ -1,7 +1,9 @@
 package umc.spring.web.dto;
 
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,4 +19,27 @@ public class MemberResponseDTO {
         Long memberId;
         LocalDateTime createdAt;
     }
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReviewPreviewDTO {
+        private String storeName;
+        private String body;
+        private Float score;
+        private LocalDate createdAt;
+    }
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReviewPreviewListDTO {
+        private List<ReviewPreviewDTO> reviewList;
+        private Integer listSize;
+        private Integer totalPage;
+        private Long totalElements;
+        private Boolean isFirst;
+        private Boolean isLast;
+    }
+
 }

--- a/spring/src/main/java/umc/spring/web/dto/MissionRequestDTO.java
+++ b/spring/src/main/java/umc/spring/web/dto/MissionRequestDTO.java
@@ -3,7 +3,11 @@ package umc.spring.web.dto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 public class MissionRequestDTO {
@@ -21,4 +25,5 @@ public class MissionRequestDTO {
         @NotNull(message = "보상은 필수입니다.")
         private Integer reward;
     }
+
 }

--- a/spring/src/main/java/umc/spring/web/dto/StoreResponseDTO.java
+++ b/spring/src/main/java/umc/spring/web/dto/StoreResponseDTO.java
@@ -57,5 +57,29 @@ public class StoreResponseDTO {
         String body;
         LocalDate createdAt;
     }
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MissionPreviewDTO {
+        private String missionSpec;
+        private Integer reward;
+        private LocalDate deadline;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MissionPreviewListDTO {
+        private List<MissionPreviewDTO> missionList;
+        private Integer listSize;
+        private Integer totalPage;
+        private Long totalElements;
+        private Boolean isFirst;
+        private Boolean isLast;
+    }
+
+
 }
 

--- a/spring/src/main/java/umc/spring/web/dto/StoreResponseDTO.java
+++ b/spring/src/main/java/umc/spring/web/dto/StoreResponseDTO.java
@@ -1,0 +1,61 @@
+package umc.spring.web.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class StoreResponseDTO {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CreateStoreResultDTO {
+        private Long storeId;
+        private String name;
+        private String address;
+        private Float score;
+        private Long regionId;
+        private LocalDateTime createdAt;
+    }
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CreateReviewResultDTO {
+        private Long reviewId;
+        private String title;
+        private Float score;
+        private Long storeId;
+        private Long memberId;
+        private LocalDateTime createdAt;
+    }
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReviewPreViewListDTO {
+        List<ReviewPreViewDTO> reviewList;
+        Integer listSize;
+        Integer totalPage;
+        Long totalElements;
+        Boolean isFirst;
+        Boolean isLast;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReviewPreViewDTO {
+        String ownerNickname;
+        Float score;
+        String body;
+        LocalDate createdAt;
+    }
+}
+


### PR DESCRIPTION
9주차 미션 요구사항에 따라 리뷰 및 미션 관련 주요 목록 API 및 상태 변경 API를 구현했습니다.
사용자 편의성과 성능을 고려하여 페이징, DTO 응답 구조화, 커스텀 어노테이션 검증, Swagger 문서화, 예외 핸들링 등을 포함했습니다.

#### 구현한 API 목록
1️⃣ 내가 작성한 리뷰 목록 조회
- Endpoint: GET /members/{memberId}/reviews?page={page}
- 기능: 회원이 작성한 리뷰를 10개씩 페이징하여 조회
- DTO: ReviewPreviewDTO, ReviewPreviewListDTO
- 기타: @ValidPage로 page 검증, Swagger 명세 완료

2️⃣ 특정 가게의 미션 목록 조회
- Endpoint: GET /stores/{storeId}/missions?page={page}
- 기능: 가게에 등록된 미션 목록 페이징 조회
- DTO: MissionPreviewDTO, MissionPreviewListDTO
- 기타: @ExistStore, @ValidPage 어노테이션 적용

3️⃣ 내가 진행 중인 미션 목록 조회
- Endpoint: GET /members/{memberId}/missions?page={page}
- 기능: 진행 상태(PROGRESSING)의 미션 목록 조회
- DTO: ChallengingMissionDTO, ChallengingMissionListDTO
- 기타: Member 및 Mission 관계 검증 포함

4️⃣ 미션 완료 처리
- Endpoint: PATCH /members/{memberId}/missions/{memberMissionId}/complete
- 기능: 진행 중인 미션을 COMPLETED 상태로 변경
- 예외 처리: 존재하지 않는 미션 → MISSION_4001, 이미 완료된 미션 → MISSION_4002