### PR TITLE
Feature/mission9 로그인 회원가입 구현

### DIFF
--- a/spring/.idea/workspace.xml
+++ b/spring/.idea/workspace.xml
@@ -4,8 +4,13 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="3368f26c-15c4-4576-b399-0c76644bea26" name="Changes" comment="jwt 설정,로그인 로직 구현">
-      <change beforePath="$PROJECT_DIR$/src/main/java/umc/spring/web/dto/MemberResponseDTO.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/umc/spring/web/dto/MemberResponseDTO.java" afterDir="false" />
+    <list default="true" id="3368f26c-15c4-4576-b399-0c76644bea26" name="Changes" comment="내 정보 조회 로직 구현">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/generated/umc/spring/domain/QMember.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/generated/umc/spring/domain/QMember.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/umc/spring/Application.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/umc/spring/Application.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/umc/spring/converter/MemberConverter.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/umc/spring/converter/MemberConverter.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/umc/spring/web/dto/MemberRequestDTO.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/umc/spring/web/dto/MemberRequestDTO.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/resources/application.yml" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/resources/application.yml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -245,7 +250,7 @@
       <workItem from="1751078823805" duration="652000" />
       <workItem from="1751266116714" duration="7000" />
       <workItem from="1751719749013" duration="862000" />
-      <workItem from="1751786006033" duration="3351000" />
+      <workItem from="1751786006033" duration="5964000" />
     </task>
     <task id="LOCAL-00001" summary="JPA 활용 실습 커밋">
       <option name="closed" value="true" />
@@ -351,7 +356,15 @@
       <option name="project" value="LOCAL" />
       <updated>1751789321940</updated>
     </task>
-    <option name="localTasksCounter" value="14" />
+    <task id="LOCAL-00014" summary="내 정보 조회 로직 구현">
+      <option name="closed" value="true" />
+      <created>1751789671782</created>
+      <option name="number" value="00014" />
+      <option name="presentableId" value="LOCAL-00014" />
+      <option name="project" value="LOCAL" />
+      <updated>1751789671782</updated>
+    </task>
+    <option name="localTasksCounter" value="15" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -371,7 +384,8 @@
     <MESSAGE value="URL 수정" />
     <MESSAGE value="SecurityConfig 설정, 로그인 로직 구현" />
     <MESSAGE value="jwt 설정,로그인 로직 구현" />
-    <option name="LAST_COMMIT_MESSAGE" value="jwt 설정,로그인 로직 구현" />
+    <MESSAGE value="내 정보 조회 로직 구현" />
+    <option name="LAST_COMMIT_MESSAGE" value="내 정보 조회 로직 구현" />
   </component>
   <component name="XDebuggerManager">
     <breakpoint-manager>

--- a/spring/.idea/workspace.xml
+++ b/spring/.idea/workspace.xml
@@ -4,25 +4,8 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="3368f26c-15c4-4576-b399-0c76644bea26" name="Changes" comment="URL 수정">
-      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/config/properties/Constants.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/config/properties/JwtProperties.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/config/security/SecurityConfig.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/config/security/jwt/JwtAuthenticationFilter.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/config/security/jwt/JwtTokenProvider.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/domain/enums/Role.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/build.gradle" beforeDir="false" afterPath="$PROJECT_DIR$/build.gradle" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/umc/spring/apiPayload/code/status/ErrorStatus.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/umc/spring/apiPayload/code/status/ErrorStatus.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/umc/spring/converter/MemberConverter.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/umc/spring/converter/MemberConverter.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/umc/spring/domain/Member.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/umc/spring/domain/Member.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/umc/spring/repository/MemberRepository/MemberRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/umc/spring/repository/MemberRepository/MemberRepository.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/umc/spring/service/MemberService/MemberCommandService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/umc/spring/service/MemberService/MemberCommandService.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/umc/spring/service/MemberService/MemberCommandServiceImpl.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/umc/spring/service/MemberService/MemberCommandServiceImpl.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/umc/spring/web/controller/MemberRestController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/umc/spring/web/controller/MemberRestController.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/umc/spring/web/dto/MemberRequestDTO.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/umc/spring/web/dto/MemberRequestDTO.java" afterDir="false" />
+    <list default="true" id="3368f26c-15c4-4576-b399-0c76644bea26" name="Changes" comment="jwt 설정,로그인 로직 구현">
       <change beforePath="$PROJECT_DIR$/src/main/java/umc/spring/web/dto/MemberResponseDTO.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/umc/spring/web/dto/MemberResponseDTO.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/resources/application.yml" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/resources/application.yml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -262,7 +245,7 @@
       <workItem from="1751078823805" duration="652000" />
       <workItem from="1751266116714" duration="7000" />
       <workItem from="1751719749013" duration="862000" />
-      <workItem from="1751786006033" duration="2909000" />
+      <workItem from="1751786006033" duration="3351000" />
     </task>
     <task id="LOCAL-00001" summary="JPA 활용 실습 커밋">
       <option name="closed" value="true" />
@@ -360,7 +343,15 @@
       <option name="project" value="LOCAL" />
       <updated>1747927554508</updated>
     </task>
-    <option name="localTasksCounter" value="13" />
+    <task id="LOCAL-00013" summary="jwt 설정,로그인 로직 구현">
+      <option name="closed" value="true" />
+      <created>1751789321940</created>
+      <option name="number" value="00013" />
+      <option name="presentableId" value="LOCAL-00013" />
+      <option name="project" value="LOCAL" />
+      <updated>1751789321940</updated>
+    </task>
+    <option name="localTasksCounter" value="14" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -378,7 +369,9 @@
     <MESSAGE value="특정 가게 미션 목록 API 구현, 페이징 적용" />
     <MESSAGE value="내가 진행중인 미션 목록(페이징 처리), 진행중인 미션 진행 완료로 바꾸기 구현 완료" />
     <MESSAGE value="URL 수정" />
-    <option name="LAST_COMMIT_MESSAGE" value="URL 수정" />
+    <MESSAGE value="SecurityConfig 설정, 로그인 로직 구현" />
+    <MESSAGE value="jwt 설정,로그인 로직 구현" />
+    <option name="LAST_COMMIT_MESSAGE" value="jwt 설정,로그인 로직 구현" />
   </component>
   <component name="XDebuggerManager">
     <breakpoint-manager>

--- a/spring/.idea/workspace.xml
+++ b/spring/.idea/workspace.xml
@@ -4,44 +4,25 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="3368f26c-15c4-4576-b399-0c76644bea26" name="Changes" comment="swagger세팅 및 회원가입 API 구현">
-      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/apiPayload/exception/handler/MemberHandler.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/apiPayload/exception/handler/MissionHandler.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/apiPayload/exception/handler/RegionHandler.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/apiPayload/exception/handler/StoreHandler.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/converter/ReviewConverter.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/converter/StoreConverter.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/repository/MissionRepository/MemberMissionRepository.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/repository/RegionRepository/RegionRepository.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/service/MissionService/MissionCommandService.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/service/MissionService/MissionCommandServiceImpl.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/service/ReviewService/ReviewCommandService.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/service/ReviewService/ReviewCommandServiceImpl.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/service/StoreService/StoreCommandService.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/service/StoreService/StoreCommandServiceImpl.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/validation/annotation/ExistStore.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/validation/annotation/NotAlreadyChallenging.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/validation/validator/NotAlreadyChallengingValidator.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/validation/validator/StoreExistValidator.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/web/controller/MissionRestController.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/web/controller/ReviewRestController.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/web/controller/StoreRestController.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/web/dto/MissionRequestDTO.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/web/dto/ReviewRequestDTO.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/web/dto/StoreRequestDTO.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.gradle/8.8/checksums/checksums.lock" beforeDir="false" afterPath="$PROJECT_DIR$/.gradle/8.8/checksums/checksums.lock" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.gradle/8.8/checksums/md5-checksums.bin" beforeDir="false" afterPath="$PROJECT_DIR$/.gradle/8.8/checksums/md5-checksums.bin" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.gradle/8.8/checksums/sha1-checksums.bin" beforeDir="false" afterPath="$PROJECT_DIR$/.gradle/8.8/checksums/sha1-checksums.bin" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.gradle/8.8/executionHistory/executionHistory.bin" beforeDir="false" afterPath="$PROJECT_DIR$/.gradle/8.8/executionHistory/executionHistory.bin" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.gradle/8.8/executionHistory/executionHistory.lock" beforeDir="false" afterPath="$PROJECT_DIR$/.gradle/8.8/executionHistory/executionHistory.lock" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.gradle/8.8/fileHashes/fileHashes.bin" beforeDir="false" afterPath="$PROJECT_DIR$/.gradle/8.8/fileHashes/fileHashes.bin" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.gradle/8.8/fileHashes/fileHashes.lock" beforeDir="false" afterPath="$PROJECT_DIR$/.gradle/8.8/fileHashes/fileHashes.lock" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.gradle/8.8/fileHashes/resourceHashesCache.bin" beforeDir="false" afterPath="$PROJECT_DIR$/.gradle/8.8/fileHashes/resourceHashesCache.bin" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.gradle/buildOutputCleanup/buildOutputCleanup.lock" beforeDir="false" afterPath="$PROJECT_DIR$/.gradle/buildOutputCleanup/buildOutputCleanup.lock" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.gradle/file-system.probe" beforeDir="false" afterPath="$PROJECT_DIR$/.gradle/file-system.probe" afterDir="false" />
+    <list default="true" id="3368f26c-15c4-4576-b399-0c76644bea26" name="Changes" comment="URL 수정">
+      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/config/properties/Constants.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/config/properties/JwtProperties.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/config/security/SecurityConfig.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/config/security/jwt/JwtAuthenticationFilter.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/config/security/jwt/JwtTokenProvider.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/umc/spring/domain/enums/Role.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/build.gradle" beforeDir="false" afterPath="$PROJECT_DIR$/build.gradle" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/umc/spring/apiPayload/code/status/ErrorStatus.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/umc/spring/apiPayload/code/status/ErrorStatus.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/umc/spring/converter/MemberConverter.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/umc/spring/converter/MemberConverter.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/umc/spring/domain/Member.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/umc/spring/domain/Member.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/umc/spring/repository/MemberRepository/MemberRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/umc/spring/repository/MemberRepository/MemberRepository.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/umc/spring/service/MemberService/MemberCommandService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/umc/spring/service/MemberService/MemberCommandService.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/umc/spring/service/MemberService/MemberCommandServiceImpl.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/umc/spring/service/MemberService/MemberCommandServiceImpl.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/umc/spring/web/controller/MemberRestController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/umc/spring/web/controller/MemberRestController.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/umc/spring/web/dto/MemberRequestDTO.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/umc/spring/web/dto/MemberRequestDTO.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/umc/spring/web/dto/MemberResponseDTO.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/umc/spring/web/dto/MemberResponseDTO.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/resources/application.yml" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/resources/application.yml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -82,11 +63,11 @@
   <component name="FileTemplateManagerImpl">
     <option name="RECENT_TEMPLATES">
       <list>
-        <option value="Enum" />
-        <option value="AnnotationType" />
         <option value="Exception" />
         <option value="Interface" />
+        <option value="AnnotationType" />
         <option value="Class" />
+        <option value="Enum" />
       </list>
     </option>
   </component>
@@ -130,7 +111,7 @@
     &quot;RequestMappingsPanelWidth1&quot;: &quot;75&quot;,
     &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
     &quot;Spring Boot.Application.executor&quot;: &quot;Run&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;feature/mission8&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;feature/mission9&quot;,
     &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
     &quot;last_opened_file_path&quot;: &quot;C:/Users/USER/SpringProjects/spring/build.gradle&quot;,
     &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
@@ -269,7 +250,19 @@
       <workItem from="1746704198113" duration="2873000" />
       <workItem from="1747124878777" duration="10000" />
       <workItem from="1747373943322" duration="11137000" />
-      <workItem from="1747392926322" duration="9672000" />
+      <workItem from="1747392926322" duration="10644000" />
+      <workItem from="1747461804351" duration="2600000" />
+      <workItem from="1747900622517" duration="2501000" />
+      <workItem from="1747903159528" duration="1503000" />
+      <workItem from="1747908346158" duration="1969000" />
+      <workItem from="1747910338369" duration="4753000" />
+      <workItem from="1747915143353" duration="1330000" />
+      <workItem from="1747916494407" duration="7253000" />
+      <workItem from="1748239788231" duration="6000" />
+      <workItem from="1751078823805" duration="652000" />
+      <workItem from="1751266116714" duration="7000" />
+      <workItem from="1751719749013" duration="862000" />
+      <workItem from="1751786006033" duration="2909000" />
     </task>
     <task id="LOCAL-00001" summary="JPA 활용 실습 커밋">
       <option name="closed" value="true" />
@@ -319,7 +312,55 @@
       <option name="project" value="LOCAL" />
       <updated>1747382119902</updated>
     </task>
-    <option name="localTasksCounter" value="7" />
+    <task id="LOCAL-00007" summary="- 회원가입 API 구현&#10;- 특정 지역에 가게 추가 API (POST /api/v1/regions/{regionId}/stores)&#10;- 가게에 리뷰 추가 API (POST /api/v1/stores/{storeId}/reviews)&#10;  - @ExistStore 커스텀 어노테이션으로 유효성 검증&#10;- 가게에 미션 추가 API (POST /api/v1/stores/{storeId}/missions)&#10;- 가게 미션 도전 API (POST /api/v1/missions/{missionId}/challenge)&#10;  - 중복 도전 방지를 위한 @NotAlreadyChallenging 커스텀 검증 어노테이션 구현&#10;  - @Validated 누락으로 인한 이슈 해결 후 정상 작동 확인">
+      <option name="closed" value="true" />
+      <created>1747402947995</created>
+      <option name="number" value="00007" />
+      <option name="presentableId" value="LOCAL-00007" />
+      <option name="project" value="LOCAL" />
+      <updated>1747402947995</updated>
+    </task>
+    <task id="LOCAL-00008" summary="특정 가게의 리뷰 목록 조회 API 구현(페이징 적용)">
+      <option name="closed" value="true" />
+      <created>1747911700257</created>
+      <option name="number" value="00008" />
+      <option name="presentableId" value="LOCAL-00008" />
+      <option name="project" value="LOCAL" />
+      <updated>1747911700257</updated>
+    </task>
+    <task id="LOCAL-00009" summary="내가 작성한 리뷰 목록 API 구현, 페이징 적용">
+      <option name="closed" value="true" />
+      <created>1747913283170</created>
+      <option name="number" value="00009" />
+      <option name="presentableId" value="LOCAL-00009" />
+      <option name="project" value="LOCAL" />
+      <updated>1747913283170</updated>
+    </task>
+    <task id="LOCAL-00010" summary="특정 가게 미션 목록 API 구현, 페이징 적용">
+      <option name="closed" value="true" />
+      <created>1747914701860</created>
+      <option name="number" value="00010" />
+      <option name="presentableId" value="LOCAL-00010" />
+      <option name="project" value="LOCAL" />
+      <updated>1747914701860</updated>
+    </task>
+    <task id="LOCAL-00011" summary="내가 진행중인 미션 목록(페이징 처리), 진행중인 미션 진행 완료로 바꾸기 구현 완료">
+      <option name="closed" value="true" />
+      <created>1747917483072</created>
+      <option name="number" value="00011" />
+      <option name="presentableId" value="LOCAL-00011" />
+      <option name="project" value="LOCAL" />
+      <updated>1747917483072</updated>
+    </task>
+    <task id="LOCAL-00012" summary="URL 수정">
+      <option name="closed" value="true" />
+      <created>1747927554508</created>
+      <option name="number" value="00012" />
+      <option name="presentableId" value="LOCAL-00012" />
+      <option name="project" value="LOCAL" />
+      <updated>1747927554508</updated>
+    </task>
+    <option name="localTasksCounter" value="13" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -331,7 +372,13 @@
     <MESSAGE value="API 작성" />
     <MESSAGE value="main 병합 BaseEntity랑 enum 디렉토리가 누락된 상태" />
     <MESSAGE value="swagger세팅 및 회원가입 API 구현" />
-    <option name="LAST_COMMIT_MESSAGE" value="swagger세팅 및 회원가입 API 구현" />
+    <MESSAGE value="- 회원가입 API 구현&#10;- 특정 지역에 가게 추가 API (POST /api/v1/regions/{regionId}/stores)&#10;- 가게에 리뷰 추가 API (POST /api/v1/stores/{storeId}/reviews)&#10;  - @ExistStore 커스텀 어노테이션으로 유효성 검증&#10;- 가게에 미션 추가 API (POST /api/v1/stores/{storeId}/missions)&#10;- 가게 미션 도전 API (POST /api/v1/missions/{missionId}/challenge)&#10;  - 중복 도전 방지를 위한 @NotAlreadyChallenging 커스텀 검증 어노테이션 구현&#10;  - @Validated 누락으로 인한 이슈 해결 후 정상 작동 확인" />
+    <MESSAGE value="특정 가게의 리뷰 목록 조회 API 구현(페이징 적용)" />
+    <MESSAGE value="내가 작성한 리뷰 목록 API 구현, 페이징 적용" />
+    <MESSAGE value="특정 가게 미션 목록 API 구현, 페이징 적용" />
+    <MESSAGE value="내가 진행중인 미션 목록(페이징 처리), 진행중인 미션 진행 완료로 바꾸기 구현 완료" />
+    <MESSAGE value="URL 수정" />
+    <option name="LAST_COMMIT_MESSAGE" value="URL 수정" />
   </component>
   <component name="XDebuggerManager">
     <breakpoint-manager>

--- a/spring/.idea/workspace.xml
+++ b/spring/.idea/workspace.xml
@@ -4,11 +4,11 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="3368f26c-15c4-4576-b399-0c76644bea26" name="Changes" comment="내 정보 조회 로직 구현">
+    <list default="true" id="3368f26c-15c4-4576-b399-0c76644bea26" name="Changes" comment="DummyDataInitializer password 필드 추가">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/generated/umc/spring/domain/QMember.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/generated/umc/spring/domain/QMember.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/umc/spring/Application.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/umc/spring/Application.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/umc/spring/converter/MemberConverter.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/umc/spring/converter/MemberConverter.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/umc/spring/domain/Member.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/umc/spring/domain/Member.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/umc/spring/service/MemberService/MemberCommandServiceImpl.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/umc/spring/service/MemberService/MemberCommandServiceImpl.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/umc/spring/web/controller/MemberRestController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/umc/spring/web/controller/MemberRestController.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/umc/spring/web/dto/MemberRequestDTO.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/umc/spring/web/dto/MemberRequestDTO.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/resources/application.yml" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/resources/application.yml" afterDir="false" />
     </list>
@@ -250,7 +250,7 @@
       <workItem from="1751078823805" duration="652000" />
       <workItem from="1751266116714" duration="7000" />
       <workItem from="1751719749013" duration="862000" />
-      <workItem from="1751786006033" duration="5964000" />
+      <workItem from="1751786006033" duration="10284000" />
     </task>
     <task id="LOCAL-00001" summary="JPA 활용 실습 커밋">
       <option name="closed" value="true" />
@@ -364,7 +364,15 @@
       <option name="project" value="LOCAL" />
       <updated>1751789671782</updated>
     </task>
-    <option name="localTasksCounter" value="15" />
+    <task id="LOCAL-00015" summary="DummyDataInitializer password 필드 추가">
+      <option name="closed" value="true" />
+      <created>1751799269102</created>
+      <option name="number" value="00015" />
+      <option name="presentableId" value="LOCAL-00015" />
+      <option name="project" value="LOCAL" />
+      <updated>1751799269102</updated>
+    </task>
+    <option name="localTasksCounter" value="16" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -385,7 +393,8 @@
     <MESSAGE value="SecurityConfig 설정, 로그인 로직 구현" />
     <MESSAGE value="jwt 설정,로그인 로직 구현" />
     <MESSAGE value="내 정보 조회 로직 구현" />
-    <option name="LAST_COMMIT_MESSAGE" value="내 정보 조회 로직 구현" />
+    <MESSAGE value="DummyDataInitializer password 필드 추가" />
+    <option name="LAST_COMMIT_MESSAGE" value="DummyDataInitializer password 필드 추가" />
   </component>
   <component name="XDebuggerManager">
     <breakpoint-manager>

--- a/spring/build.gradle
+++ b/spring/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	// Spring Boot 기본 의존성
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 
 	// MySQL 드라이버
 	runtimeOnly 'mysql:mysql-connector-java:8.0.33'
@@ -52,7 +53,7 @@ dependencies {
 	// 테스트 의존성
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-
+	testImplementation 'org.springframework.security:spring-security-test'
 	//에러 핸들링
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
@@ -61,6 +62,11 @@ dependencies {
 
 	//데이터베이스 검증
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 sourceSets {

--- a/spring/src/main/generated/umc/spring/domain/QMember.java
+++ b/spring/src/main/generated/umc/spring/domain/QMember.java
@@ -43,9 +43,13 @@ public class QMember extends EntityPathBase<Member> {
 
     public final StringPath name = createString("name");
 
+    public final StringPath password = createString("password");
+
     public final NumberPath<Integer> point = createNumber("point", Integer.class);
 
     public final ListPath<Review, QReview> reviewList = this.<Review, QReview>createList("reviewList", Review.class, QReview.class, PathInits.DIRECT2);
+
+    public final EnumPath<umc.spring.domain.enums.Role> role = createEnum("role", umc.spring.domain.enums.Role.class);
 
     public final EnumPath<umc.spring.domain.enums.SocialType> socialType = createEnum("socialType", umc.spring.domain.enums.SocialType.class);
 

--- a/spring/src/main/java/umc/spring/Application.java
+++ b/spring/src/main/java/umc/spring/Application.java
@@ -1,24 +1,14 @@
 package umc.spring;
 
-import jakarta.persistence.EntityManager;
-import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-import umc.spring.domain.Member;
-import umc.spring.domain.Mission;
-import umc.spring.domain.Region;
-import umc.spring.domain.Review;
-import umc.spring.domain.Store;
-import umc.spring.domain.enums.MissionStatus;
-import umc.spring.domain.mapping.MemberMission;
-import umc.spring.service.MemberService.MemberQueryService;
-import umc.spring.service.MissionService.MissionQueryService;
-import umc.spring.service.ReviewService.ReviewQueryService;
-import umc.spring.service.StoreService.StoreQueryService;
+import umc.spring.domain.FoodCategory;
+import umc.spring.repository.FoodCategoryRepository.FoodCategoryRepository;
 
 @SpringBootApplication
 @EnableJpaAuditing
@@ -27,52 +17,27 @@ public class Application {
 	public static void main(String[] args) {
 		SpringApplication.run(Application.class, args);
 	}
-	@Bean
-	public CommandLineRunner storeQueryTest(ApplicationContext context) {
-		return args -> {
-			StoreQueryService storeService = context.getBean(StoreQueryService.class);
-			String name = "요아정";
-			Float score = 4.0f;
-			System.out.println("🟢 Store Query: name=" + name + ", score=" + score);
-			storeService.findStoresByNameAndScore(name, score)
-					.forEach(System.out::println);
-		};
-	}
+
 
 	@Bean
-	public CommandLineRunner missionQueryTest(ApplicationContext context) {
+	public CommandLineRunner foodCategoryInitializer(FoodCategoryRepository foodCategoryRepository) {
 		return args -> {
-			MissionQueryService missionQueryService = context.getBean(MissionQueryService.class);
-			Long memberId = 1L;
-			MissionStatus status = MissionStatus.CHALLENGING;
-			System.out.println("🟢 Mission Query: memberId=" + memberId + ", status=" + status);
-			missionQueryService.getMissionsByStatusAndMember(memberId, status, 0, 10)
-					.forEach(System.out::println);
-		};
-	}
+			if (foodCategoryRepository.count() == 0) {
+				List<String> categoryNames = List.of(
+						"양식", "일식", "한식", "치킨", "분식",
+						"고기/구이", "도시락", "야식(족발, 보쌈)",
+						"패스트푸드", "디저트", "아시안푸드"
+				);
 
-	@Bean
-	public CommandLineRunner reviewQueryTest(ApplicationContext context) {
-		return args -> {
-			ReviewQueryService reviewQueryService = context.getBean(ReviewQueryService.class);
-			Long storeId = 1L;
-			System.out.println("🟢 Review Query: storeId=" + storeId);
-			reviewQueryService.getReviewsBeforeCursor(storeId, LocalDateTime.now(), 5)
-					.forEach(System.out::println);
-		};
-	}
+				List<FoodCategory> categories = categoryNames.stream()
+						.map(name -> FoodCategory.builder().name(name).build())
+						.collect(Collectors.toList());
 
-	@Bean
-	public CommandLineRunner memberQueryTest(ApplicationContext context) {
-		return args -> {
-			MemberQueryService memberQueryService = context.getBean(MemberQueryService.class);
-			Long memberId = 1L;
-			System.out.println("🟢 Member Query: memberId=" + memberId);
-			memberQueryService.getMemberInfo(memberId)
-					.ifPresentOrElse(
-							System.out::println,
-							() -> System.out.println("❌ Member not found.")
-					);
+				foodCategoryRepository.saveAll(categories);
+				System.out.println("✅ 음식 카테고리 초기 데이터가 삽입되었습니다.");
+			} else {
+				System.out.println("ℹ️ 음식 카테고리가 이미 존재합니다.");
+			}
 		};
 	}
 

--- a/spring/src/main/java/umc/spring/apiPayload/code/status/ErrorStatus.java
+++ b/spring/src/main/java/umc/spring/apiPayload/code/status/ErrorStatus.java
@@ -15,6 +15,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
     //푸드 카테고리 관련 에러
     FOOD_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND,"FOOD CATEGORY4001", "해당 음식 카테고리를 찾을 수 없습니다."),
     STORE_NOT_FOUND( HttpStatus.NOT_FOUND,"STORE_4001", "존재하지 않는 가게입니다."),
@@ -22,6 +23,9 @@ public enum ErrorStatus implements BaseErrorCode {
     // 멤버 관려 에러
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다."),
     NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER4002", "닉네임은 필수 입니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "MEMBER4003", "패스워드가 불일치합니다."),
+    DUPLICATE_JOIN_REQUEST(HttpStatus.BAD_REQUEST, "MEMBER4004", "해당 이메일로 이미 가입된 사용자가 존재합니다."),
+    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "MEMBER4005", "유효하지 않은 토큰입니다."),
 
     //지역 관련 에러
     REGION_NOT_FOUND(HttpStatus.NOT_FOUND,"REGION_4001", "존재하지 않는 지역입니다."),

--- a/spring/src/main/java/umc/spring/config/DummyDataInitializer.java
+++ b/spring/src/main/java/umc/spring/config/DummyDataInitializer.java
@@ -1,47 +1,61 @@
 package umc.spring.config;
 
 import jakarta.persistence.EntityManager;
-import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import umc.spring.domain.*;
 import umc.spring.domain.enums.MissionStatus;
+import umc.spring.domain.enums.Role;
+import umc.spring.domain.enums.SocialType;
 import umc.spring.domain.mapping.MemberMission;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component
-@RequiredArgsConstructor
 public class DummyDataInitializer implements CommandLineRunner {
 
     private final EntityManager em;
+    private final PasswordEncoder passwordEncoder;
 
-    @Override
+    public DummyDataInitializer(EntityManager em, PasswordEncoder passwordEncoder) {
+        this.em = em;
+        this.passwordEncoder = passwordEncoder;
+    }
+
     @Transactional
+    @Override
     public void run(String... args) throws Exception {
-        // ▶ 1. Region 생성
+        // ✅ 1. Region
         Region seoul = Region.builder().name("서울").build();
         em.persist(seoul);
 
-        // ▶ 2. Store 생성
+        // ✅ 2. Store
         Store store = Store.builder()
                 .name("요아정")
                 .address("서울시 강남구")
-                .score(4.5f)
+                .score(4.5F)
                 .region(seoul)
                 .build();
         em.persist(store);
 
-        // ▶ 3. Member 생성
+        // ✅ 3. Member (비밀번호 포함)
+        String encodedPassword = passwordEncoder.encode("abc1234");
         Member member = Member.builder()
                 .name("홍길동")
                 .email("hong@example.com")
                 .address("서울시 마포구")
                 .specAddress("서울시 마포구 백범로 1")
+                .password(encodedPassword)
                 .point(100)
+                .role(Role.USER)
+                .socialType(SocialType.KAKAO)
                 .build();
         em.persist(member);
 
-        // ▶ 4. Mission 생성
+        // ✅ 4. Mission
         Mission mission = Mission.builder()
                 .missionSpec("요아정 첫 방문 미션")
                 .reward(3000)
@@ -49,7 +63,7 @@ public class DummyDataInitializer implements CommandLineRunner {
                 .build();
         em.persist(mission);
 
-        // ▶ 5. MemberMission 생성
+        // ✅ 5. MemberMission
         MemberMission mm = MemberMission.builder()
                 .member(member)
                 .mission(mission)
@@ -57,18 +71,28 @@ public class DummyDataInitializer implements CommandLineRunner {
                 .build();
         em.persist(mm);
 
-        // ▶ 6. Review 생성
+        // ✅ 6. Review
         Review review = Review.builder()
                 .title("맛있어요!")
-                .score(5.0f)
+                .score(5.0F)
                 .store(store)
                 .member(member)
                 .build();
         em.persist(review);
 
-        em.flush(); // 변경 사항 강제 반영
+        // ✅ 7. FoodCategory (중복 방지용 SELECT 먼저 해도 됨)
+        List<String> categoryNames = List.of(
+                "양식", "일식", "한식", "치킨", "분식",
+                "고기/구이", "도시락", "야식(족발, 보쌈)",
+                "패스트푸드", "디저트", "아시안푸드"
+        );
+        List<FoodCategory> categories = categoryNames.stream()
+                .map(name -> FoodCategory.builder().name(name).build())
+                .collect(Collectors.toList());
+        categories.forEach(em::persist);
 
-        System.out.println("✅ 더미 데이터 삽입 완료");
+        em.flush();
+
+        System.out.println("✅ 더미 데이터 + 음식 카테고리 + 암호화된 비밀번호 삽입 완료");
     }
 }
-

--- a/spring/src/main/java/umc/spring/config/properties/Constants.java
+++ b/spring/src/main/java/umc/spring/config/properties/Constants.java
@@ -1,0 +1,6 @@
+package umc.spring.config.properties;
+
+public final class Constants {
+    public static final String AUTH_HEADER = "Authorization";
+    public static final String TOKEN_PREFIX = "Bearer ";
+}

--- a/spring/src/main/java/umc/spring/config/properties/JwtProperties.java
+++ b/spring/src/main/java/umc/spring/config/properties/JwtProperties.java
@@ -1,0 +1,22 @@
+package umc.spring.config.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+@Setter
+@ConfigurationProperties("jwt.token")
+public class JwtProperties {
+    private String secretKey="";
+    private Expiration expiration;
+
+    @Getter
+    @Setter
+    public static class Expiration{
+        private Long access;
+        // TODO: refreshToken
+    }
+}

--- a/spring/src/main/java/umc/spring/config/security/SecurityConfig.java
+++ b/spring/src/main/java/umc/spring/config/security/SecurityConfig.java
@@ -1,0 +1,46 @@
+package umc.spring.config.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import umc.spring.config.security.jwt.JwtAuthenticationFilter;
+import umc.spring.config.security.jwt.JwtTokenProvider;
+
+@EnableWebSecurity
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .authorizeHttpRequests(
+                        (requests) -> requests
+                                .requestMatchers("/", "/members/join", "/members/login", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                                .requestMatchers("/admin/**").hasRole("ADMIN")
+                                .anyRequest().authenticated()
+                )
+                .csrf()
+                .disable()
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/spring/src/main/java/umc/spring/config/security/jwt/JwtAuthenticationFilter.java
+++ b/spring/src/main/java/umc/spring/config/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,44 @@
+package umc.spring.config.security.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+import umc.spring.config.properties.Constants;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String token = resolveToken(request);
+
+        if(StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(Constants.AUTH_HEADER);
+        if(StringUtils.hasText(bearerToken) && bearerToken.startsWith(Constants.TOKEN_PREFIX)) {
+            return bearerToken.substring(Constants.TOKEN_PREFIX.length());
+        }
+        return null;
+    }
+}
+

--- a/spring/src/main/java/umc/spring/config/security/jwt/JwtTokenProvider.java
+++ b/spring/src/main/java/umc/spring/config/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,84 @@
+package umc.spring.config.security.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import umc.spring.apiPayload.code.status.ErrorStatus;
+import umc.spring.apiPayload.exception.handler.MemberHandler;
+import umc.spring.config.properties.Constants;
+import umc.spring.config.properties.JwtProperties;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.Collections;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private final JwtProperties jwtProperties;
+
+    private Key getSigningKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes());
+    }
+
+    public String generateToken(Authentication authentication) {
+        String email = authentication.getName();
+
+        return Jwts.builder()
+                .setSubject(email)
+                .claim("role", authentication.getAuthorities().iterator().next().getAuthority())
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + jwtProperties.getExpiration().getAccess()))
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(getSigningKey())
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        String email = claims.getSubject();
+        String role = claims.get("role", String.class);
+
+        User principal = new User(email, "", Collections.singleton(() -> role));
+        return new UsernamePasswordAuthenticationToken(principal, token, principal.getAuthorities());
+    }
+
+    public static String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(Constants.AUTH_HEADER);
+        if(StringUtils.hasText(bearerToken) && bearerToken.startsWith(Constants.TOKEN_PREFIX)) {
+            return bearerToken.substring(Constants.TOKEN_PREFIX.length());
+        }
+        return null;
+    }
+
+    public Authentication extractAuthentication(HttpServletRequest request){
+        String accessToken = resolveToken(request);
+        if(accessToken == null || !validateToken(accessToken)) {
+            throw new MemberHandler(ErrorStatus.INVALID_TOKEN);
+        }
+        return getAuthentication(accessToken);
+    }
+}

--- a/spring/src/main/java/umc/spring/converter/MemberConverter.java
+++ b/spring/src/main/java/umc/spring/converter/MemberConverter.java
@@ -25,6 +25,13 @@ public class MemberConverter {
                 .build();
     }
 
+    public static MemberResponseDTO.LoginResultDTO toLoginResultDTO(Long memberId, String accessToken) {
+        return MemberResponseDTO.LoginResultDTO.builder()
+                .memberId(memberId)
+                .accessToken(accessToken)
+                .build();
+    }
+
     public static Member toMember(MemberRequestDTO.JoinDto request){
 
         Gender gender = null;

--- a/spring/src/main/java/umc/spring/converter/MemberConverter.java
+++ b/spring/src/main/java/umc/spring/converter/MemberConverter.java
@@ -63,6 +63,8 @@ public class MemberConverter {
                 .name(request.getName())
                 .memberPreferList(new ArrayList<>())
                 .email(request.getEmail())
+                .password(request.getPassword())
+                .role(request.getRole())
                 .build();
     }
 

--- a/spring/src/main/java/umc/spring/converter/MemberConverter.java
+++ b/spring/src/main/java/umc/spring/converter/MemberConverter.java
@@ -32,6 +32,14 @@ public class MemberConverter {
                 .build();
     }
 
+    public static MemberResponseDTO.MemberInfoDTO toMemberInfoDTO(Member member){
+        return MemberResponseDTO.MemberInfoDTO.builder()
+                .name(member.getName())
+                .email(member.getEmail())
+                .gender(member.getGender().name())
+                .build();
+    }
+
     public static Member toMember(MemberRequestDTO.JoinDto request){
 
         Gender gender = null;

--- a/spring/src/main/java/umc/spring/domain/Member.java
+++ b/spring/src/main/java/umc/spring/domain/Member.java
@@ -23,6 +23,7 @@ import org.hibernate.annotations.DynamicUpdate;
 import umc.spring.domain.common.BaseEntity;
 import umc.spring.domain.enums.Gender;
 import umc.spring.domain.enums.MemberStatus;
+import umc.spring.domain.enums.Role;
 import umc.spring.domain.enums.SocialType;
 import umc.spring.domain.mapping.MemberAgree;
 import umc.spring.domain.mapping.MemberMission;
@@ -65,6 +66,12 @@ public class Member extends BaseEntity {
 
     @Column(nullable = false, length = 50)
     private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
 
     @ColumnDefault("0")
     private Integer point;

--- a/spring/src/main/java/umc/spring/domain/Member.java
+++ b/spring/src/main/java/umc/spring/domain/Member.java
@@ -98,4 +98,7 @@ public class Member extends BaseEntity {
                 '}';
     }
 
+    public void encodePassword(String password) {
+        this.password = password;
+    }
 }

--- a/spring/src/main/java/umc/spring/domain/enums/Role.java
+++ b/spring/src/main/java/umc/spring/domain/enums/Role.java
@@ -1,0 +1,5 @@
+package umc.spring.domain.enums;
+
+public enum Role {
+    ADMIN, USER
+}

--- a/spring/src/main/java/umc/spring/repository/MemberRepository/MemberRepository.java
+++ b/spring/src/main/java/umc/spring/repository/MemberRepository/MemberRepository.java
@@ -1,7 +1,17 @@
 package umc.spring.repository.MemberRepository;
 
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import umc.spring.domain.Member;
+import umc.spring.domain.enums.MemberStatus;
 
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
+
+    @Query("SELECT m FROM Member m WHERE m.name = :name AND m.status = :status")
+    List<Member> findByNameAndStatus(@Param("name") String name, @Param("status") MemberStatus status);
+
+    Optional<Member> findByEmail(String email);
 }

--- a/spring/src/main/java/umc/spring/service/MemberService/MemberCommandService.java
+++ b/spring/src/main/java/umc/spring/service/MemberService/MemberCommandService.java
@@ -3,10 +3,12 @@ package umc.spring.service.MemberService;
 import jakarta.transaction.Transactional;
 import umc.spring.domain.Member;
 import umc.spring.web.dto.MemberRequestDTO;
+import umc.spring.web.dto.MemberResponseDTO;
 
 public interface MemberCommandService {
     @Transactional
     Member joinMember(MemberRequestDTO.JoinDto request);
     void completeMission(Long memberId, Long memberMissionId);
+    MemberResponseDTO.LoginResultDTO loginMember(MemberRequestDTO.LoginRequestDTO request);
 
 }

--- a/spring/src/main/java/umc/spring/service/MemberService/MemberCommandServiceImpl.java
+++ b/spring/src/main/java/umc/spring/service/MemberService/MemberCommandServiceImpl.java
@@ -1,13 +1,18 @@
 package umc.spring.service.MemberService;
 
 import jakarta.transaction.Transactional;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import umc.spring.apiPayload.code.status.ErrorStatus;
 import umc.spring.apiPayload.exception.handler.FoodCategoryHandler;
 import umc.spring.apiPayload.exception.handler.MemberHandler;
+import umc.spring.config.security.jwt.JwtTokenProvider;
 import umc.spring.converter.MemberConverter;
 import umc.spring.converter.MemberPreferConverter;
 import umc.spring.domain.FoodCategory;
@@ -19,6 +24,7 @@ import umc.spring.repository.FoodCategoryRepository.FoodCategoryRepository;
 import umc.spring.repository.MemberRepository.MemberRepository;
 import umc.spring.repository.MissionRepository.MemberMissionRepository;
 import umc.spring.web.dto.MemberRequestDTO;
+import umc.spring.web.dto.MemberResponseDTO;
 
 @Service
 @RequiredArgsConstructor
@@ -28,6 +34,8 @@ public class MemberCommandServiceImpl implements MemberCommandService{
 
     private final FoodCategoryRepository foodCategoryRepository;
     private final MemberMissionRepository memberMissionRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
     @Override
@@ -61,4 +69,25 @@ public class MemberCommandServiceImpl implements MemberCommandService{
         memberMission.changeStatus(MissionStatus.COMPLETE);
     }
 
+    @Override
+    public MemberResponseDTO.LoginResultDTO loginMember(MemberRequestDTO.LoginRequestDTO request) {
+        Member member = memberRepository.findByEmail(request.getEmail())
+                .orElseThrow(()-> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        if(!passwordEncoder.matches(request.getPassword(), member.getPassword())) {
+            throw new MemberHandler(ErrorStatus.INVALID_PASSWORD);
+        }
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                member.getEmail(), null,
+                Collections.singleton(() -> member.getRole().name())
+        );
+
+        String accessToken = jwtTokenProvider.generateToken(authentication);
+
+        return MemberConverter.toLoginResultDTO(
+                member.getId(),
+                accessToken
+        );
+    }
 }

--- a/spring/src/main/java/umc/spring/service/MemberService/MemberCommandServiceImpl.java
+++ b/spring/src/main/java/umc/spring/service/MemberService/MemberCommandServiceImpl.java
@@ -44,6 +44,8 @@ public class MemberCommandServiceImpl implements MemberCommandService{
         System.out.println("📌 요청 받은 카테고리 ID들: " + request.getPreferCategory());
 
         Member newMember = MemberConverter.toMember(request);
+        newMember.encodePassword(passwordEncoder.encode(request.getPassword()));
+
         List<FoodCategory> foodCategoryList = request.getPreferCategory().stream()
                 .map(category -> {
                     return foodCategoryRepository.findById(category).orElseThrow(() -> new FoodCategoryHandler(

--- a/spring/src/main/java/umc/spring/service/MemberService/MemberQueryService.java
+++ b/spring/src/main/java/umc/spring/service/MemberService/MemberQueryService.java
@@ -1,5 +1,6 @@
 package umc.spring.service.MemberService;
 
+import jakarta.servlet.http.HttpServletRequest;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -8,6 +9,7 @@ import umc.spring.domain.Member;
 import umc.spring.domain.Mission;
 import umc.spring.domain.Review;
 import umc.spring.domain.mapping.MemberMission;
+import umc.spring.web.dto.MemberResponseDTO;
 
 public interface MemberQueryService {
     Optional<Member> getMemberInfo(Long memberId);
@@ -15,5 +17,5 @@ public interface MemberQueryService {
     List<Mission> getMissionsByRegionBeforeCursor(Long regionId, LocalDateTime cursorTime, int limit);
 
     Page<MemberMission> getChallengingMissions(Long memberId, int page);
-
+    MemberResponseDTO.MemberInfoDTO getMemberInfo(HttpServletRequest request);
 }

--- a/spring/src/main/java/umc/spring/service/MemberService/MemberQueryServiceImpl.java
+++ b/spring/src/main/java/umc/spring/service/MemberService/MemberQueryServiceImpl.java
@@ -1,15 +1,19 @@
 package umc.spring.service.MemberService;
 
+import jakarta.servlet.http.HttpServletRequest;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.spring.apiPayload.code.status.ErrorStatus;
 import umc.spring.apiPayload.exception.handler.MemberHandler;
+import umc.spring.config.security.jwt.JwtTokenProvider;
+import umc.spring.converter.MemberConverter;
 import umc.spring.domain.Member;
 import umc.spring.domain.Mission;
 import umc.spring.domain.Review;
@@ -18,6 +22,7 @@ import umc.spring.domain.mapping.MemberMission;
 import umc.spring.repository.MemberRepository.MemberRepository;
 import umc.spring.repository.MissionRepository.MemberMissionRepository;
 import umc.spring.repository.ReviewRepository.ReviewRepository;
+import umc.spring.web.dto.MemberResponseDTO;
 
 @Service
 @RequiredArgsConstructor
@@ -27,6 +32,7 @@ public class MemberQueryServiceImpl implements MemberQueryService {
     private final MemberRepository memberRepository;
     private final ReviewRepository reviewRepository;
     private final MemberMissionRepository memberMissionRepository;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Override
     public Optional<Member> getMemberInfo(Long memberId) {
@@ -53,6 +59,16 @@ public class MemberQueryServiceImpl implements MemberQueryService {
 
         return memberMissionRepository.findAllByMemberAndStatus(member, MissionStatus.CHALLENGING,
                 PageRequest.of(page, 10));
+    }
+    @Override
+    @Transactional(readOnly = true)
+    public MemberResponseDTO.MemberInfoDTO getMemberInfo(HttpServletRequest request){
+        Authentication authentication = jwtTokenProvider.extractAuthentication(request);
+        String email = authentication.getName();
+
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(()-> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        return MemberConverter.toMemberInfoDTO(member);
     }
 
 }

--- a/spring/src/main/java/umc/spring/web/controller/MemberRestController.java
+++ b/spring/src/main/java/umc/spring/web/controller/MemberRestController.java
@@ -65,5 +65,11 @@ public class MemberRestController {
         return ApiResponse.onSuccess(MemberConverter.toChallengingMissionListDTO(missions));
     }
 
+    @PostMapping("/login")
+    @Operation(summary = "유저 로그인 API",description = "유저가 로그인하는 API입니다.")
+    public ApiResponse<MemberResponseDTO.LoginResultDTO> login(@RequestBody @Valid MemberRequestDTO.LoginRequestDTO request) {
+        return ApiResponse.onSuccess(memberCommandService.loginMember(request));
+    }
+
 
 }

--- a/spring/src/main/java/umc/spring/web/controller/MemberRestController.java
+++ b/spring/src/main/java/umc/spring/web/controller/MemberRestController.java
@@ -36,7 +36,7 @@ public class MemberRestController {
     private final MemberCommandService memberCommandService;
     private final MemberQueryService memberQueryService;
 
-    @PostMapping("/")
+    @PostMapping("/join")
     public ApiResponse<MemberResponseDTO.JoinResultDTO> join(@RequestBody @Valid MemberRequestDTO.JoinDto request){
         Member member = memberCommandService.joinMember(request);
         return ApiResponse.onSuccess(MemberConverter.toJoinResultDTO(member));

--- a/spring/src/main/java/umc/spring/web/controller/MemberRestController.java
+++ b/spring/src/main/java/umc/spring/web/controller/MemberRestController.java
@@ -2,6 +2,8 @@ package umc.spring.web.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -71,5 +73,13 @@ public class MemberRestController {
         return ApiResponse.onSuccess(memberCommandService.loginMember(request));
     }
 
+    @GetMapping("/info")
+    @Operation(summary = "유저 내 정보 조회 API - 인증 필요",
+            description = "유저가 내 정보를 조회하는 API입니다.",
+            security = { @SecurityRequirement(name = "JWT TOKEN") }
+    )
+    public ApiResponse<MemberResponseDTO.MemberInfoDTO> getMyInfo(HttpServletRequest request) {
+        return ApiResponse.onSuccess(memberQueryService.getMemberInfo(request));
+    }
 
 }

--- a/spring/src/main/java/umc/spring/web/dto/MemberRequestDTO.java
+++ b/spring/src/main/java/umc/spring/web/dto/MemberRequestDTO.java
@@ -31,12 +31,6 @@ public class MemberRequestDTO {
         Integer gender;
         @NotBlank
         String password;
-        @NotNull
-        Integer birthYear;
-        @NotNull
-        Integer birthMonth;
-        @NotNull
-        Integer birthDay;
         @Size(min = 5, max = 12)
         String address;
         @Size(min = 5, max = 12)

--- a/spring/src/main/java/umc/spring/web/dto/MemberRequestDTO.java
+++ b/spring/src/main/java/umc/spring/web/dto/MemberRequestDTO.java
@@ -1,13 +1,26 @@
 package umc.spring.web.dto;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 import lombok.Getter;
+import lombok.Setter;
 import umc.spring.validation.annotation.ExistCategories;
 
 public class MemberRequestDTO {
+
+    @Getter
+    @Setter
+    public static class LoginRequestDTO{
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "올바른 이메일 형식이어야 합니다.")
+        private String email;
+
+        @NotBlank(message = "패스워드는 필수입니다.")
+        private String password;
+    }
 
     @Getter
     public static class JoinDto{

--- a/spring/src/main/java/umc/spring/web/dto/MemberRequestDTO.java
+++ b/spring/src/main/java/umc/spring/web/dto/MemberRequestDTO.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.Size;
 import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
+import umc.spring.domain.enums.Role;
 import umc.spring.validation.annotation.ExistCategories;
 
 public class MemberRequestDTO {
@@ -28,6 +29,8 @@ public class MemberRequestDTO {
         String name;
         @NotNull
         Integer gender;
+        @NotBlank
+        String password;
         @NotNull
         Integer birthYear;
         @NotNull
@@ -42,5 +45,7 @@ public class MemberRequestDTO {
         List<Integer> preferCategory;
         @NotBlank
         String email;
+        @NotNull
+        Role role;
     }
 }

--- a/spring/src/main/java/umc/spring/web/dto/MemberResponseDTO.java
+++ b/spring/src/main/java/umc/spring/web/dto/MemberResponseDTO.java
@@ -15,6 +15,15 @@ public class MemberResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class LoginResultDTO {
+        Long memberId;
+        String accessToken;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class JoinResultDTO{
         Long memberId;
         LocalDateTime createdAt;
@@ -64,6 +73,5 @@ public class MemberResponseDTO {
         private Boolean isFirst;
         private Boolean isLast;
     }
-
 
 }

--- a/spring/src/main/java/umc/spring/web/dto/MemberResponseDTO.java
+++ b/spring/src/main/java/umc/spring/web/dto/MemberResponseDTO.java
@@ -73,5 +73,13 @@ public class MemberResponseDTO {
         private Boolean isFirst;
         private Boolean isLast;
     }
-
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberInfoDTO{
+        String name;
+        String email;
+        String gender;
+    }
 }

--- a/spring/src/main/resources/application.yml
+++ b/spring/src/main/resources/application.yml
@@ -19,7 +19,7 @@ spring:
         format_sql: true
         use_sql_comments: true
         hbm2ddl:
-          auto: update
+          auto: create
         default_batch_fetch_size: 1000
 
 

--- a/spring/src/main/resources/application.yml
+++ b/spring/src/main/resources/application.yml
@@ -19,15 +19,15 @@ spring:
         format_sql: true
         use_sql_comments: true
         hbm2ddl:
-          auto: create
+          auto: update
         default_batch_fetch_size: 1000
 
 
-  logging:
+logging:
     level:
       org.springframework.web: DEBUG
 
-  jwt:
+jwt:
     token:
       secretKey: umceightfightingjwttokenauthentication
       expiration:

--- a/spring/src/main/resources/application.yml
+++ b/spring/src/main/resources/application.yml
@@ -27,3 +27,9 @@ spring:
     level:
       org.springframework.web: DEBUG
 
+  jwt:
+    token:
+      secretKey: umceightfightingjwttokenauthentication
+      expiration:
+        access: 14400000
+


### PR DESCRIPTION
 ### 주요 기능

- 회원가입 API (/members/join) 구현

  - 이메일, 비밀번호, 이름, 성별, 주소, 선호 카테고리 등을 입력 받아 회원을 등록
  
  - 패스워드 암호화 적용

- 로그인 API (/members/login) 구현
  
  - email & password를 검증 후 JWT Access Token 발급
  
  - 로그인 성공 시 accessToken 과 memberId를 담은 LoginResultDTO 반환

- JWT Access Token 기반 인증 구현

  - JwtTokenProvider: 토큰 생성, 검증, 인증 객체 추출
  
  - JwtAuthenticationFilter: 모든 요청에서 Access Token을 검사 및 인증 처리
  
  - /members/info에서 인증된 사용자만 자신의 정보를 조회 가능

- 내 정보 조회 API (/members/info) 구현

  - JWT 토큰을 통해 인증된 사용자의 이름, 이메일, 성별 반환

### 설정/구조 변경

- build.gradle

  - JWT 라이브러리 추가
  
  - application.yml

- yml
  - JwtProperties 클래스 생성 및 @ConfigurationProperties 적용
  → yml 설정 값을 객체로 주입 받아 사용
  
  - Constants 클래스 생성
  → AUTH_HEADER, TOKEN_PREFIX 상수값 정의

- SecurityConfig 수정

  - /members/join, /members/login 등의 경로는 permitAll() 처리
  
  - JwtAuthenticationFilter를 Spring Security FilterChain에 등록

### 트러블슈팅

![스크린샷 2025-07-06 205102](https://github.com/user-attachments/assets/b0bf0bcc-ba0b-4e62-b9b9-3208821227f9)
→ application.yml의 jwt 설정이 spring 항목안에 잘못 들어가 있어서 에러가 발생하였습니다. jwt: 설정을 spring: 블록 내부가 아니라 최상단 레벨로 빼내어 정의해줌으로써, @ConfigurationProperties("jwt.token")가 정상적으로 값을 읽어올 수 있게 되어 문제가 해결되었습니다.

- 로그인 시 "패스워드가 불일치합니다" 오류 발생
→ 로그인 시 암호화된 비밀번호와의 비교를 위해 passwordEncoder.encode(request.getPassword() 로직을 MemberCommandServiceImpl에 추가하여 회원가입 시 비밀번호를 암호화 하도록 구현하여 해결하였습니다. 

### 테스트 결과

- 회원가입 API /members/join

  - Swagger에서 정상적으로 회원 등록 확인 (HTTP 200)

- 로그인 API /members/login

  - 정상 로그인 후 accessToken 반환 확인
![스크린샷 2025-07-06 205915](https://github.com/user-attachments/assets/d1829d5b-570f-4bcc-a226-0a93000b1663)

- 내 정보 조회 API /members/info

  - 로그인 후 발급받은 토큰을 Authorization 헤더에 포함하여 요청 시, 가입 정보 정상 반환
 
![스크린샷 2025-07-06 210226](https://github.com/user-attachments/assets/54c3793c-3d9b-45e6-842b-a93a696dfb8b)
